### PR TITLE
fix for the blog-details page and drafts 'no-drafts' message

### DIFF
--- a/resources/themes/ghost/templates/blog-details.html
+++ b/resources/themes/ghost/templates/blog-details.html
@@ -161,7 +161,7 @@
         margin-top: 3em;
     }
 
-    .blog-posts img{
+    .blog-posts p img{
         width:788px;
         height: 406px;
     }
@@ -216,23 +216,18 @@
             font-size: 28px;
         }
 
-        .blog-posts img{
+        .blog-posts p img{
             width:345px;
             height: 177px;
         }
     }
 
     @media screen and (max-width:900px) and (min-width:700px) {
-        .blog-posts img{
+        .blog-posts p img{
             width:546px;
             height: 281px;
         }
 
-    }
-   
-
-    p img{
-        width:100%;
     }
 
 

--- a/resources/themes/ghost/templates/drafts.html
+++ b/resources/themes/ghost/templates/drafts.html
@@ -304,7 +304,7 @@
 
                     {% else %}
                     <div class="row">
-                            <div class="no-drafts-alert mx-auto">
+                            <div class="no-drafts-alert mx-auto my-5">
                                 <p class="text-grey">
                                     You have no drafts
                                 </p>


### PR DESCRIPTION
### TITLE OF PR
fix for the blog-details page and drafts 'no-drafts' message

### PURPOSE OF PR
To fix the oversized icons in the blog details page
To add margin to the 'no more drafts' message

### Add page screen shot from your local
![Screenshot_2019-05-14 Lucid](https://user-images.githubusercontent.com/33119163/57726783-c76d4380-7687-11e9-87de-ed2b07764896.png)
