### PR TITLE
Hidden post-id field on the published-posts page restored

### DIFF
--- a/resources/themes/ghost/templates/published-posts.html
+++ b/resources/themes/ghost/templates/published-posts.html
@@ -461,6 +461,7 @@
                         </div>
                         <div class="col-12">
                           <div id="editor">{{ post.body|raw }}</div>
+                          <input type="hidden" id="postid" value="" class="form-control hide" />
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
### TITLE OF PR
Hidden post-id field on the published-posts page